### PR TITLE
Fix punctuation and ortography

### DIFF
--- a/main/templates/index.html
+++ b/main/templates/index.html
@@ -110,19 +110,19 @@
              <div class="row">
                 <div class="col-lg-8 col-lg-offset-2">
                 {% blocktrans %}
-                    <p>You have students around 10 years-old and you want to teach them about programming.</p>
-                    <p><b>What do you think is the best way to do this ?</b></p>
+                    <p>You have students around 10 years old, and you want to teach them about programming.</p>
+                    <p><b>What do you think is the best way to do this?</b></p>
                     <p><b><a href="https://microbit.org">BBC</a></b> took this seriously and they decided to develop, together with more than 20 partners, <b>BBC Micro:bit</b>.<br />
                         An amazing device, with a 5x5 matrix leds, a lot of inputs and sensors.<br />
                         Then the <b><a href="https://pyfound.blogspot.co.uk/2016/03/a-million-children.html">Python Software Foundation</a></b>
-                        jumped in and said that it was a super cool project, why don't we put <b><a href="https://www.python.org">Python</a></b> inside it ?<br />
-                        <p>The result ?</p>
-                    <p>You can use BBC Micro:bit and Python to teach young students about programming, you can do this having fun and with a programming
-                        language used almost everywhere.</p>
-                    <p>And about <b>Microbit:Polska</b> ?</p>
+                        jumped in and said that it was a super cool project, why don't we put <b><a href="https://www.python.org">Python</a></b> inside it?<br />
+                        <p>The result?</p>
+                    <p>You can use BBC Micro:bit and Python to teach young students about programming. You can do this while having fun, and with a programming
+                        language that is used almost everywhere.</p>
+                    <p>What about <b>Microbit:Polska</b>?</p>
                     <p>Well in UK they gave <b><a href="http://www.bbc.co.uk/mediacentre/latestnews/2016/bbc-micro-bit-schools-launch">1 million Micro:bits</a></b>
-                        to school children for free, why we should not have something similar in Poland ?</p>
-                    <p>Come join in the fun !</p>
+                        to school children for free, why we should not have something similar in Poland?</p>
+                    <p>Come join in the fun!</p>
                 {% endblocktrans %}
 
                 </div>
@@ -143,19 +143,19 @@
             <div class="row">
                 <div class="col-lg-8 col-lg-offset-2">
                 {% blocktrans %}
-                    <p>The workshop is called <b>FunWithMicrobit</b>, and that is the goal, having fun with it.</p>
+                    <p>The workshop is called <b>FunWithMicrobit</b>, and that is the goal: having fun with it.</p>
 
-                    <p>It is around 6 hours, the first 4 hours will be dedicated in teaching how you can use BBC Micro:bit and program it with Python.</p>
+                    <p>It takes around 6 hours: the first 4 hours are dedicated to teaching how to use the BBC Micro:bit and program it with Python.</p>
 
                     <p>Python is an open source programming language, easy to learn and easy to use, that perfectly fits Micro:bit.</p>
 
-                    <p>The last 2 hours will be an open lab, where you develop your Micro:bit
-                        project helped by the Python programmers and then present it.</p>
+                    <p>The last 2 hours are an open lab, where you develop your Micro:bit
+                        project, helped by the Python programmers, and then show it to others.</p>
 
-                    <p>A workshop is generally formed by 30 students, 5 teachers and 5 Python programmers,
-                        and it is generally held during one day of the week-end.</p>
-                    <p>You can check the materials of the workshop <a href="https://github.com/MicrobitPolska/FunWithMicrobit">here</a>.</p>
-                    <p>Do you want to host a workshop in your school ?</p>
+                    <p>A workshop is formed by 30 students, 5 teachers and 5 Python programmers,
+                        and it is held during one day of the week-end.</p>
+                    <p>You can check <a href="https://github.com/MicrobitPolska/FunWithMicrobit">the materials for the workshop</a>.</p>
+                    <p>Do you want to host a workshop at your school?</p>
                 {% endblocktrans %}
                 </div>
 
@@ -252,9 +252,9 @@
             <div class="row">
                 <div class="col-lg-8 col-lg-offset-2">
                     {% blocktrans %}
-                    <p><b>Microbit:Polska</b> is a project made up from people with different skills, personalities and experiences.
+                    <p><b>Microbit:Polska</b> is a project made up of people with different skills, personalities and experiences.
                         <br />
-                        And it is through these differences that this project can grow up and evolve.
+                        And it is through these differences that this project can grow and evolve.
                     </p>
                     <p>We believe that as a Student, Teacher and Programmer we should be driven by being <b>#open</b>, <b>#considerate</b> and <b>#respectful</b>.</p>
 
@@ -267,7 +267,7 @@
                     <p>For the long version we decided to use the <a href="http://berlincodeofconduct.org/"><b>Berlin Code of Conduct</b></a>.</p>
 
 
-                     <p>Questions/Comments/Reports ?</p>
+                     <p>Questions/Comments/Reports?</p>
                     <p>For anything related to the Code of Conduct feel free to write to the Microbit:Polska organisers: info@microbitpolska.org
                     </p>
                     {% endblocktrans %}
@@ -354,7 +354,7 @@
                     </div>
                     <div class="footer-col col-md-4">
                         <h3>{% trans "About Microbit:Polska" %}</h3>
-                        <p>{% trans "Microbit:Polska is a project with a very specific goal: teaching about programming with fun !" %}</p>
+                        <p>{% trans "Microbit:Polska is a project with a very specific goal: teaching about programming with fun!" %}</p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Both in English and in Polish it is a typographical error to place a full space before the question mark or the exclamation mark (or before any other punctuation, in general). The space should go after the mark.

Fixed some prepositions and made some of the sentences less ambiguous and easier to read.